### PR TITLE
Frequency units

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -54,7 +54,7 @@ Reexport = "1.2.2"
 SLEEFPirates = "0.6.42"
 StaticArrays = "1.9.2"
 TicraUtilities = "1.1.2"
-Triangulate = "2.3.2"
+Triangulate = "3"
 Unitful = "1.19.0"
 julia = "1"
 

--- a/docs/literate/manual.jl
+++ b/docs/literate/manual.jl
@@ -13,14 +13,14 @@
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "subslide"}}
 # There are ``N \ge 2`` dielectric layers. The ``k``th layer is
 # characterized by its complex permittivity ``\epsilon_k``, complex
-# permeability ``\mu_k``, and width ``h_k`` (except for outer layers ``1`` and ``N`` 
-# which are assumed to be semi-infinite).  There are ``N-1`` junction planes 
-# separating the layers. At some of these junction planes there may exist 
+# permeability ``\mu_k``, and width ``h_k`` (except for outer layers ``1`` and ``N``
+# which are assumed to be semi-infinite).  There are ``N-1`` junction planes
+# separating the layers. At some of these junction planes there may exist
 # frequency selective surfaces (FSSs) or polarization selective surfaces (PSSs)
-# consisting of zero-thickness periodic patterns of metalization. 
+# consisting of zero-thickness periodic patterns of metalization.
 # PSSFSS will determine the generalized scattering matrix (GSM) for this structure
 # which fully characterizes it in terms of illumination by an incoming plane wave
-# of arbitrary polarization incident from either Region ``1`` or Region ``N``.  
+# of arbitrary polarization incident from either Region ``1`` or Region ``N``.
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "slide"}}
 # ### A Quick Example
@@ -31,15 +31,15 @@
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "subslide"}}
 # ```julia
 # using PSSFSS
-# outersheet = meander(a=0.3535, b=0.707, h=0.28, w1=0.018, 
+# outersheet = meander(a=0.3535, b=0.707, h=0.28, w1=0.018,
 #                      w2=0.018, ntri=800, units=inch,rot=45)
-# innersheet = meander(a=0.3535, b=0.707, h=0.37, w1=0.027, 
+# innersheet = meander(a=0.3535, b=0.707, h=0.37, w1=0.027,
 #                      w2=0.027, ntri=800, units=inch,rot=45)
 # flist = 3:0.1:9
 # steering = (ϕ=0, θ=0)
 # substrate = Layer(ϵᵣ=2.52, width=0.01inch)
 # spacer(width) = Layer(width=width, ϵᵣ=1.08)
-# strata = [  Layer(), 
+# strata = [  Layer(),
 #             outersheet, substrate, spacer(0.2inch),
 #             innersheet, substrate, spacer(0.3inch),
 #             innersheet, substrate, spacer(0.2inch),
@@ -53,7 +53,7 @@
 # Assuming that the above code is contained in the file "blackney.jl"
 # it can be run from the Julia prompt via `include("blackney.jl")`,
 # after which a CSV file "blackney.csv" is
-# created, containing the frequency in GHz in the first column and 
+# created, containing the frequency in GHz in the first column and
 # axial ratio in dB in the second. It can be plotted in Julia as follows:
 # ```julia
 # using Plots, DelimitedFiles
@@ -72,8 +72,8 @@
 # presented in the paper. Here is the comparison plot:
 #
 # ![blackney](./assets/blackney_polarizer_comparison.png)
-# 
-# The PSSFSS run took about 14 seconds on my machine for 4 meanderline PSS sheets 
+#
+# The PSSFSS run took about 14 seconds on my machine for 4 meanderline PSS sheets
 # analyzed at 61 frequencies.
 #
 # I hope this example whetted your appetite to learn
@@ -82,54 +82,54 @@
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "slide"}}
 # ### Recommendations for Hardware and Software
 
-# [PSSFSS](https://github.com/simonp0420/PSSFSS) is 
+# [PSSFSS](https://github.com/simonp0420/PSSFSS) is
 # written in the [Julia](https://julialang.org/) programming language
 # which means that you must have Julia installed to use PSSFSS.
-# For most users, I recommend using the 
+# For most users, I recommend using the
 # [Juliaup](https://github.com/JuliaLang/juliaup#readme) app to handle
-# installation and updating of Julia. 
+# installation and updating of Julia.
 # At the time of this writing, Juliaup is available for Windows, Macs and
 # most Linux distributions. If it is not yet available for your platform,
-# then consider using [JILL.py](https://github.com/johnnychen94/jill.py) to 
+# then consider using [JILL.py](https://github.com/johnnychen94/jill.py) to
 # manage the installation.
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "subslide"}}
 # It goes without saying that computational electromagnetics is compute intensive. You will
 # want to run PSSFSS on a rather "beefy" machine. A machine with multiple cores
-# will provide the best experience since the code is multi-threaded. 
-# Also, PSSFSS can use a lot of RAM--a minimum of 16 GBytes RAM is recommended.  
+# will provide the best experience since the code is multi-threaded.
+# Also, PSSFSS can use a lot of RAM--a minimum of 16 GBytes RAM is recommended.
 # The examples provided in this documentation were run on either a Windows or Linux machine,
 # both equipped with an
-# 8-core Intel(R) Core(TM) i7-9700 processor clocked at 3 GHz, with either 32 GBytes (Windows) or 
-# 64 GBytes (Linux) RAM, with multi-threading enabled via the `-t auto` Julia startup option. 
-# **Multi-threading must be explicitly enabled at startup in Julia.**  Please see 
+# 8-core Intel(R) Core(TM) i7-9700 processor clocked at 3 GHz, with either 32 GBytes (Windows) or
+# 64 GBytes (Linux) RAM, with multi-threading enabled via the `-t auto` Julia startup option.
+# **Multi-threading must be explicitly enabled at startup in Julia.**  Please see
 # [this section](https://docs.julialang.org/en/v1/manual/multi-threading/#man-multithreading) of the Julia
-# documentation for details.  On Windows I have (for some cases) experienced significant speedups by using the 
-# [MKL](https://github.com/JuliaLinearAlgebra/MKL.jl) package.  On Linux, I find that the `MKL` package 
+# documentation for details.  On Windows I have (for some cases) experienced significant speedups by using the
+# [MKL](https://github.com/JuliaLinearAlgebra/MKL.jl) package.  On Linux, I find that the `MKL` package
 # sometimes actually results in slower execution. YMMV.
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "subslide"}}
 # You will need a text editor to create Julia scripts that run PSSFSS.  One of the best for this purpose
 # is [VS Code](https://code.visualstudio.com/), which has extensive support for editing, running, debugging,
-# and profiling Julia via the 
+# and profiling Julia via the
 # [julia-vscode](https://github.com/julia-vscode/julia-vscode) extension.
-# Whatever your choice of editor, installation and 
-# use of the [JuliaMono](https://juliamono.netlify.app) fonts is 
+# Whatever your choice of editor, installation and
+# use of the [JuliaMono](https://juliamono.netlify.app) fonts is
 # highly recommended. JuliaMono has extensive coverage of Unicode mathematical symbols. With JuliaMono
-# installed on your system, Julia's support for Unicode fonts allows one to use standard 
-# engineering/mathematical symbols for electromagnetic quantities directly in Julia scripts; 
-# symbols such as ϵᵣ, μᵣ, θ, ϕ, and tanδ.  Entering these symbols is very easy in either VS Code, the 
-# Julia REPL (command line), or a notebook environment. 
+# installed on your system, Julia's support for Unicode fonts allows one to use standard
+# engineering/mathematical symbols for electromagnetic quantities directly in Julia scripts;
+# symbols such as ϵᵣ, μᵣ, θ, ϕ, and tanδ.  Entering these symbols is very easy in either VS Code, the
+# Julia REPL (command line), or a notebook environment.
 
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "subslide"}}
-# An alternative to using a text editor is to run scripts from a Jupyter or Pluto notebook.  See the  
+# An alternative to using a text editor is to run scripts from a Jupyter or Pluto notebook.  See the
 # [IJulia](https://github.com/JuliaLang/IJulia.jl) package for further details on using Jupyter, and
 # the [Pluto Home Page](https://plutojl.org/) for details of using Pluto.
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "fragment"}}
 # It is essential that PSSFSS users also install the [Plots](https://github.com/JuliaPlots/Plots.jl)
-# package.  This will allow easy visualization of the FSS/PSS element triangulations produced by PSSFSS, in 
+# package.  This will allow easy visualization of the FSS/PSS element triangulations produced by PSSFSS, in
 # addition to providing a convenient means to plot analysis results.
 
 
@@ -138,10 +138,10 @@
 # Here are the steps in the analysis process.
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "fragment"}}
-# 1. Strata: Specify the type and geometry of the FSS/PSS sheet(s) and intervening dielectric layers. 
+# 1. Strata: Specify the type and geometry of the FSS/PSS sheet(s) and intervening dielectric layers.
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "fragment"}}
-# 2. Steering: Specify the desired values of the unit cell incremental phasing or of 
+# 2. Steering: Specify the desired values of the unit cell incremental phasing or of
 #    the set of incidence angles to be considered.
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "fragment"}}
@@ -155,7 +155,7 @@
 #    a "results" file, and the output files specified in Step 4.
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "subslide"}}
-# 6. Optionally, extract additional outputs from the results returned by [`analyze`](@ref) 
+# 6. Optionally, extract additional outputs from the results returned by [`analyze`](@ref)
 #    or from the results file via a call to [`extract_result`](@ref).
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "fragment"}}
@@ -164,10 +164,10 @@
 # Each of these steps is examined in detail below...
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "slide"}}
-# ## Strata 
+# ## Strata
 # The geometry to be analyzed is passed as the first argument of the [`analyze`](@ref) function in the form
-# of a Julia `Vector` (i.e., a one-dimensional array). This vector must contain at least two `Layer` 
-# objects representing dielectric layers, and zero or more `RWGSheet` instances, representing the zero-thickness 
+# of a Julia `Vector` (i.e., a one-dimensional array). This vector must contain at least two `Layer`
+# objects representing dielectric layers, and zero or more `RWGSheet` instances, representing the zero-thickness
 # PSS or FSS sheets located between the dielectric layers.  These are described below.
 # ### Dielectric Layers
 # Dielectric layers are created with the [`Layer`](@ref) constructor function:
@@ -200,7 +200,7 @@ patch = rectstrip(Nx=10, Ny=10, Px=1, Py=1, Lx=0.5, Ly=0.5, units=cm)
 # As with all Julia functions, you can get documentation for [`rectstrip`](@ref) by typing `?rectstrip` at the Julia prompt.
 # [`rectstrip`](@ref) can be used to model dipoles, strip grids, ground planes, rectangular reflectarray elements, and rectangular
 # patch elements.
-# A call to [`rectstrip`](@ref) generates a rectangular strip, which by default (i.e. when `rot=0`) is oriented with its sides parallel 
+# A call to [`rectstrip`](@ref) generates a rectangular strip, which by default (i.e. when `rot=0`) is oriented with its sides parallel
 # to the x and y axes.  It should be noted that it is permissible for either or both strip side lengths to be equal to
 # the corresponding unit cell dimension (i.e. `Lx==Px` and/or `Ly==Py`). In this case currents are allowed to flow
 # continuously across the unit cell boundaries.   Currently, this is the only way to model an
@@ -208,13 +208,13 @@ patch = rectstrip(Nx=10, Ny=10, Px=1, Py=1, Lx=0.5, Ly=0.5, units=cm)
 #
 # Other FSS/PSS element types: [`diagstrip`](@ref), [`jerusalemcross`](@ref), [`loadedcross`](@ref),
 # [`manji`](@ref), [`meander`](@ref), [`pecsheet`](@ref), [`pmcsheet`](@ref), [`polyring`](@ref), [`sinuous`](@ref),
-# and [`splitring`](@ref).  A later section of this documentation, the 
+# and [`splitring`](@ref).  A later section of this documentation, the
 # [Element Gallery](https://simonp0420.github.io/PSSFSS.jl/stable/PSS_&_FSS_Element_Gallery/),
 # provides several plots of each element type in "demo card" format.  Clicking on one of these cards will open a page containing
 # detailed geometry plots and the code used to generate them.
 #
 # Sheet triangulations can be exported to ASCII or binary STL files using the [`export_sheet`](@ref) function.
-# 
+#
 #-
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "subslide"}}
 # #### RWGSheet Classes
@@ -229,18 +229,18 @@ patch = rectstrip(Nx=10, Ny=10, Px=1, Py=1, Lx=0.5, Ly=0.5, units=cm)
 # By default, any `RWGSheet` represents a zero-thickness, perfectly conducting sheet.  But for sheets of class `J`,
 # one can specify the frequency-independent sheet surface impedance in units of [Ω] using the optional
 # keyword argument `Zsheet`.  Alternatively, one can specify the metal's bulk, DC conductivity and
-# optionally, the RMS surface roughness and associated probability distribution. Conductivity is specified by 
-# either of the keywords `sigma` or `σ` in units of [S/m], while RMS surface roughness is specified by the keyword 
-# `Rq` in units of [m]. The RMS surface roughness defaults to 0, denoting a smooth surface.  The probability 
-# distribution function for roughness is specified by the keyword `disttype` which can be either `:normal` (the 
-# default value, suitable for the so-called "oxide side" of a planar conductor, or `:rayleigh` (suitable for the 
-# "foil side" of the conductor, i.e. the side bonded to the dielectric substrate). Together, the conductivity, 
-# surface roughness, and roughness distribution type are used by PSSFSS internally to compute a frequency-dependent surface 
+# optionally, the RMS surface roughness and associated probability distribution. Conductivity is specified by
+# either of the keywords `sigma` or `σ` in units of [S/m], while RMS surface roughness is specified by the keyword
+# `Rq` in units of [m]. The RMS surface roughness defaults to 0, denoting a smooth surface.  The probability
+# distribution function for roughness is specified by the keyword `disttype` which can be either `:normal` (the
+# default value, suitable for the so-called "oxide side" of a planar conductor, or `:rayleigh` (suitable for the
+# "foil side" of the conductor, i.e. the side bonded to the dielectric substrate). Together, the conductivity,
+# surface roughness, and roughness distribution type are used by PSSFSS internally to compute a frequency-dependent surface
 # impedance, using the so-called Gradient Model, as described in [grujic2021simple](@cite).
 # Obviously, only one of `Zsheet` and `sigma` may be specified as keyword arguments for a given `RWGSheet`.
 
 # #### Perfectly Conducting Walls
-# For modeling a perfectly electric conducting, unperforated ground plane (E-wall) 
+# For modeling a perfectly electric conducting, unperforated ground plane (E-wall)
 # there is the [`pecsheet`](@ref) function.  Similary,
 # one can use the [`pmcsheet`](@ref) function to model an H-wall.
 
@@ -249,16 +249,16 @@ patch = rectstrip(Nx=10, Ny=10, Px=1, Py=1, Lx=0.5, Ly=0.5, units=cm)
 # We can visualize the triangulation using the `plot` function of the [`Plots`](https://docs.juliaplots.org) package.
 
 #nb %% A slide [code] {"slideshow": {"slide_type": "fragment"}}
-using Plots 
+using Plots
 plot(patch)
 #-
-#md # ![patch1](./assets/patch1.png) 
+#md # ![patch1](./assets/patch1.png)
 
 #-
 #nb %% A slide [code] {"slideshow": {"slide_type": "subslide"}}
-plot(patch, linecolor=:red, unitcell=true) 
+plot(patch, linecolor=:red, unitcell=true)
 #-
-#md # ![patch2](./assets/patch2.png) 
+#md # ![patch2](./assets/patch2.png)
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "fragment"}}
 # Here we changed the color and turned on the unit cell outline.  Other optional
@@ -285,7 +285,7 @@ plot(patch, linecolor=:red, unitcell=true)
 #nb %% A slide [code] {"slideshow": {"slide_type": "subslide"}}
 plot(patch, rep=(4,3)) # Show multiple FSS elements
 #-
-#md # ![patch3](./assets/patch3.png) 
+#md # ![patch3](./assets/patch3.png)
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "slide"}}
 # ### Strata: The full structure geometry
@@ -299,21 +299,21 @@ strata = [Layer(), patch, Layer()] # A vector of RWGSheet and Layer objects
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "slide"}}
 # ## Steering
 # You can specify a set of plane wave incidence angles to be analyzed, or a set of progressive phase
-# shifts. 
+# shifts.
 # ### Steering Choice: Specify Incidence angles
-# The steering angles 
-# ``\theta^{\text{inc}}`` and ``\phi^\text{inc}`` 
+# The steering angles
+# ``\theta^{\text{inc}}`` and ``\phi^\text{inc}``
 # specify the the incident wavevector for the plane wave illuminating the structure:
 # ```math
-#  \vec{k}_1 = k_1(\hat{x} \sin\theta^\text{inc} \cos \phi^\text{inc} + 
+#  \vec{k}_1 = k_1(\hat{x} \sin\theta^\text{inc} \cos \phi^\text{inc} +
 #                 \hat{y} \sin\theta^\text{inc} \sin \phi^\text{inc} + \hat{z} \cos\theta^\text{inc})
 #    \quad \text{(Region} \, 1 \, \text{incidence)}
 #    \\
-#   \vec{k}_N = k_N(\hat{x} \sin\theta^\text{inc} \cos \phi^\text{inc} + 
+#   \vec{k}_N = k_N(\hat{x} \sin\theta^\text{inc} \cos \phi^\text{inc} +
 #                 \hat{y} \sin\theta^\text{inc} \sin \phi^\text{inc} - \hat{z} \cos\theta^\text{inc})
 #    \quad \text{(Region} \, N \, \text{incidence)}
 # ```
-# Here ``1`` refers to the first `Layer` specified in the `strata` vector, and ``N`` 
+# Here ``1`` refers to the first `Layer` specified in the `strata` vector, and ``N``
 # refers to the last.
 # Use a [named tuple](https://docs.julialang.org/en/v1/manual/functions/#Named-Tuples)
 # to specify the set of steering angles to be analyzed. Here are some
@@ -322,10 +322,10 @@ steer = (θ=0, ϕ=0) # The most common case.  Note that "inc" is implied and not
 steer = (θ=0:15:45, ϕ=[0,90])
 steer = (phi=[0,90], theta=[0,15,30,45]) # Can use ASCII names if desired
 # The last two assignments above are equivalent as inputs to `analyze`, except for the order in which
-# the angles will be processed. `analyze` will execute a triple loop consisting of the two 
-# incidence angles and frequency.  Frequency is always the innermost loop so it will vary most 
+# the angles will be processed. `analyze` will execute a triple loop consisting of the two
+# incidence angles and frequency.  Frequency is always the innermost loop so it will vary most
 # rapidly. In the second line above, since `θ`
-# was specified first, it will be iterated in the outermost loop and will thus vary the slowest. In 
+# was specified first, it will be iterated in the outermost loop and will thus vary the slowest. In
 # the last example above, `ϕ` will be iterated in the outmost loop, then `θ`, then frequency.
 #
 #-
@@ -335,9 +335,9 @@ steer = (phi=[0,90], theta=[0,15,30,45]) # Can use ASCII names if desired
 # ```math
 #  V(\vec{r} + m\vec{s}_1 + n\vec{s}_2) = e^{-j(m\psi_1 + n\psi_2)} V(\vec{r})
 # ```
-# for all integers ``m`` and ``n``, where ``\vec{s}_1`` and ``\vec{s}_2`` 
+# for all integers ``m`` and ``n``, where ``\vec{s}_1`` and ``\vec{s}_2``
 # are the *primitive lattice vectors* of the 2D periodic structure, and
-# ``\psi_1`` and ``\psi_2`` 
+# ``\psi_1`` and ``\psi_2``
 # are the incremental phase shifts (a pair of real numbers).  Specify
 # the phasings in degrees as a named tuple as in either of the following two examples:
 steer = (ψ₁=10:10:40, ψ₂=0:5:15)
@@ -350,32 +350,35 @@ steer = (psi1=10:10:40, psi2=0) # Can use ASCII names if desired
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "subslide"}}
 # ### Steering: Which Choice?
 # Because of the unique wide-band Green's function formulation used by PSSFSS,
-# it is significantly (several times) faster to perform a frequency sweep if the incremental 
-# phase shifts are held constant with frequency, rather than the incidence 
+# it is significantly (several times) faster to perform a frequency sweep if the incremental
+# phase shifts are held constant with frequency, rather than the incidence
 # angles.  The only exception is normal incidence, i.e. θ = 0, which implies
 # that ``\psi_1 = \psi_2 = 0`` for all frequencies.
 # Note however, that by sweeping frequency over a number of different phasings,
-# one can "cover" any desired range of scan angles. 
+# one can "cover" any desired range of scan angles.
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "slide"}}
 # ## Analysis Frequencies
-# Frequencies to be analyzed are entered in GHz as either a scalar value or a Julia "iterable collection"
+# Frequencies to be analyzed are by default entered in GHz as either a scalar value or a Julia "iterable collection"
 # such as a `Vector` or `Range`:
 flist = 12
 flist = 2:2:12 # same as [2,4,6,8,10,12]
 flist = union(7:0.5:10, 20:0.5:25) # Two frequency bands
-
+# To specify frequencies in, say THz, use the [string macro](https://docs.julialang.org/en/v1/) from the
+# [`Unitful`](https://github.com/JuliaPhysics/Unitful.jl) package, provided as a convenience by PSSFSS:
+flist = (2:2:12) * u"THz"
+# Any `Unitful` unit having the correct dimension (inverse time) can be used (including of course `u"GHz"`).
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "slide"}}
 # ## Outputs
 # ### Standard Output Files
 # By default PSSFSS will create a log file named "pssfss.log" and a results file named "pssfss.res".
 # The former is a text file and the latter is a binary ([JLD2](https://github.com/JuliaIO/JLD2.jl)) file.
-# The log file contains a recapitulation of the geometry being analyzed and a report on the progress 
-# and timing of the analysis. The results file contains the generalized scattering matrices computed 
-# by PSSFSS along with other information needed to generate any of the output parameters to be described 
-# shortly. The names used for these two files can be specified using the `logfile` and `resultfile` 
-# keyword arguments to `analyze`. If you wish to bypass creation of either of these files 
+# The log file contains a recapitulation of the geometry being analyzed and a report on the progress
+# and timing of the analysis. The results file contains the generalized scattering matrices computed
+# by PSSFSS along with other information needed to generate any of the output parameters to be described
+# shortly. The names used for these two files can be specified using the `logfile` and `resultfile`
+# keyword arguments to `analyze`. If you wish to bypass creation of either of these files
 # (not recommended), use, e.g. `resultfile=devnull` in the call to `analyze`.
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "subslide"}}
@@ -384,7 +387,7 @@ flist = union(7:0.5:10, 20:0.5:25) # Two frequency bands
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "subslide"}}
 # #### Scattering Parameters Computed by PSSFSS
-# The scattering matrix computed by PSSFSS relates the incoming and outgoing TE and TM 
+# The scattering matrix computed by PSSFSS relates the incoming and outgoing TE and TM
 # travelling wave coefficients
 # for Layers ``1`` and ``N`` of the stratified structure:
 #
@@ -399,29 +402,29 @@ flist = union(7:0.5:10, 20:0.5:25) # Two frequency bands
 # | ![twvectors](./assets/twvectors.png)|
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "subslide"}}
-# So we see that the individual partitions of the scattering matrix are each a ``2 \times 2`` matrix, with 
-# ``\boldsymbol{S}^{11}`` and ``\boldsymbol{S}^{22}`` containing reflection coefficients and 
+# So we see that the individual partitions of the scattering matrix are each a ``2 \times 2`` matrix, with
+# ``\boldsymbol{S}^{11}`` and ``\boldsymbol{S}^{22}`` containing reflection coefficients and
 # ``\boldsymbol{S}^{12}`` and ``\boldsymbol{S}^{21}`` containing transmission coefficients.
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "subslide"}}
-# #### The @outputs macro 
+# #### The @outputs macro
 # The [`@outputs`](@ref) [macro](https://docs.julialang.org/en/v1/manual/metaprogramming/#man-macros) is used
 # to request output performance parameters.  It can be used in three different ways:
-#  1. It can be used as part of the `outlist` keyword argument to [`analyze`](@ref) to set up the 
+#  1. It can be used as part of the `outlist` keyword argument to [`analyze`](@ref) to set up the
 #     outputs to be written to one or more CSV files during the analysis run.
-#  2. It can be used to create an input argument to [`extract_result`](@ref) to extract performance 
+#  2. It can be used to create an input argument to [`extract_result`](@ref) to extract performance
 #     parameters from the results file generated by a previous analysis run.
-#  3. It can be used to create an input argument to [`extract_result`](@ref) to extract performance 
+#  3. It can be used to create an input argument to [`extract_result`](@ref) to extract performance
 #     parameters from the Julia variable returned by the [`analyze`](@ref) function.
 #-
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "fragment"}}
-# We'll see how to accomplish all these in a bit, but first let's look at the syntax and semantics 
+# We'll see how to accomplish all these in a bit, but first let's look at the syntax and semantics
 # of using [`@outputs`](@ref).
 # As a first example, we can request the ``(1,2)`` entry of $\boldsymbol{S}^{21}$ via the following code:
 # ```julia
 # @outputs s21(1,2)
 # ```
-# Recall that this is the transmission coefficient for the amount of outgoing TE plane wave in Layer ``N`` due 
+# Recall that this is the transmission coefficient for the amount of outgoing TE plane wave in Layer ``N`` due
 # to illuminating Layer ``1`` with an incoming TM plane wave.
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "subslide"}}
@@ -429,40 +432,40 @@ flist = union(7:0.5:10, 20:0.5:25) # Two frequency bands
 # ```julia
 # @outputs S21(te,tm) # Note that case is not significant
 # ```
-# The above code fragment is exactly equivalent to the former one.  Case (capitalization) is not 
-# significant for the arguments of the `@outputs` macro, so `s21(TE,tm)`, `S21(TE,TM)`, 
+# The above code fragment is exactly equivalent to the former one.  Case (capitalization) is not
+# significant for the arguments of the `@outputs` macro, so `s21(TE,tm)`, `S21(TE,TM)`,
 # etc. are all equivalent.
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "fragment"}}
-# The previous constructions will fetch the coefficient as a complex number.  Most of the time this is not 
+# The previous constructions will fetch the coefficient as a complex number.  Most of the time this is not
 # desired. To obtain the magnitude in dB, use e.g. `S21dB(te,tm)` and to obtain the phase angle in degrees use
 # e.g. `S21ang(te,tm)`.  Again, case is not significant, and "1" and "te" can be freely interchanged, as can
 # "2" and "tm".
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "fragment"}}
-# It is often desired to use a set of polarization basis vectors other than TE/TM to define field 
-# coefficients.  PSSFSS supports in addition to TE/TM the use of H/V for horizontal/vertical components 
+# It is often desired to use a set of polarization basis vectors other than TE/TM to define field
+# coefficients.  PSSFSS supports in addition to TE/TM the use of H/V for horizontal/vertical components
 # (in the Ludwig 3 [ludw:73](@cite) sense), and L/R for left-hand circular
-# and right-hand circular polarization (in the 
+# and right-hand circular polarization (in the
 # [IEEE sense](https://en.wikipedia.org/wiki/Circular_polarization#Uses_of_the_two_conventions)).
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "subslide"}}
 # ##### Examples
-# Here is an example for multiple outputs: frequency in GHz, crosspol reflection coefficient in Layer 1, 
-# axial ratio (in dB) for the outgoing wave in Layer 1 due to incoming horizontally 
+# Here is an example for multiple outputs: frequency in GHz, crosspol reflection coefficient in Layer 1,
+# axial ratio (in dB) for the outgoing wave in Layer 1 due to incoming horizontally
 # polarized wave in Layer ``N``:
 # ```julia
 # @outputs FGHz s11dB(h,v) ar12dB(h)
 # ```
-# Note that multiple arguments to [`@outputs`](@ref) are separated by spaces, **with no commas or other 
+# Note that multiple arguments to [`@outputs`](@ref) are separated by spaces, **with no commas or other
 # punctuation between**[^1].
 
-# [^1]: An [alternative](https://docs.julialang.org/en/v1/manual/metaprogramming/#Macro-invocation) 
-#       syntax is, e.g. `@outputs(FGHz, s11dB(h,v), ar12dB(h))` with no spaces 
+# [^1]: An [alternative](https://docs.julialang.org/en/v1/manual/metaprogramming/#Macro-invocation)
+#       syntax is, e.g. `@outputs(FGHz, s11dB(h,v), ar12dB(h))` with no spaces
 #       between the macro name and the opening parenthesis.
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "subslide"}}
-# Another example for multiple outputs: frequency in GHz, incidence angles ``\theta`` and ``\phi``, 
+# Another example for multiple outputs: frequency in GHz, incidence angles ``\theta`` and ``\phi``,
 # transmission coefficient magnitudes in dB to LHCP and RHCP for a vertically polarized incident wave:
 # ```julia
 # @outputs FGHz θ ϕ s21dB(L,v) s21dB(R,V)
@@ -473,12 +476,12 @@ flist = union(7:0.5:10, 20:0.5:25) # Two frequency bands
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "subslide"}}
 # #### Table of Valid `@outputs` Parameters
-# All parameters taking arguments can use any of `1`, `2`, `TE`, `TM`, `H`, `V`, `L`, and `R`. The 
+# All parameters taking arguments can use any of `1`, `2`, `TE`, `TM`, `H`, `V`, `L`, and `R`. The
 # parameters and their argument(s) can be typed without regard to capitalization.
 #
 # |Name(s)                             |# of Arguments| Description                        |
 # |:-----------------------------------|:------------:|:-----------------------------------|
-# |FGHz, FMHz                          | 0            | Frequency in GHz or MHz, resp.     |
+# |FTHz, FGHz, FMHz, FkHz, FHz         | 0            | Frequency in THz, GHz, ..., Hz, resp.|
 # |θ, theta, ϕ, phi                    | 0            | Incidence angles in degrees        |
 # |ψ₁, ψ₂, psi1, psi2                  | 0            | Incremental phase shifts in degrees|
 # | s11, s12, s21, s22                 | 2            | Complex coefficient                |
@@ -495,7 +498,7 @@ flist = union(7:0.5:10, 20:0.5:25) # Two frequency bands
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "subslide"}}
 # #### The `outlist` Keyword Argument to `analyze`
 # `outlist` is used to specify data to be written to CSV files during the PSSFSS analysis,
-# in the form of a matrix with one or more rows. Each row starts with a string containing 
+# in the form of a matrix with one or more rows. Each row starts with a string containing
 # the name of a CSV file; the rest of the row is an invocation of [`@outputs`](@ref) (or the result of
 # such an invocation assigned to a Julia variable).  Here is an example that will create a pair
 # of CSV files, one containing transmission coefficient magnitudes and the other containing
@@ -507,9 +510,9 @@ flist = union(7:0.5:10, 20:0.5:25) # Two frequency bands
 #           "reflected.csv"    @outputs FGHz s11dB(h,h) s11dB(v,v) ]
 # ...
 # analyze(strata, flist, (θ=0, ϕ=0), outlist=csvout)
-# ``` 
-# The matrix is delineated using 
-# [square brackets](https://docs.julialang.org/en/v1/manual/arrays/#man-array-literals). 
+# ```
+# The matrix is delineated using
+# [square brackets](https://docs.julialang.org/en/v1/manual/arrays/#man-array-literals).
 # Note that there can be no commas between entries in a row. If more than a single incidence
 # angle had been specified then we would also have wanted to include incidence angles in the
 # CSV files.
@@ -518,7 +521,7 @@ flist = union(7:0.5:10, 20:0.5:25) # Two frequency bands
 # #### Using the Result File
 # The result file generated by [`analyze`](@ref) can be used to obtain any quantity available to the [`@outputs`](@ref)
 # macro.  Consider the Blackney meanderline polarizer example presented earlier.  For that run,
-# the result file name was left at its default value "pssfss.res".  We can use the [`extract_result`](@ref) 
+# the result file name was left at its default value "pssfss.res".  We can use the [`extract_result`](@ref)
 # function to extract results from it as follows:
 #
 # ```julia
@@ -530,19 +533,19 @@ flist = union(7:0.5:10, 20:0.5:25) # Two frequency bands
 # 3.75  3.3334
 # 4.0   2.42903
 # 4.25  1.64223
-# ⋮     
+# ⋮
 # 8.25  1.91583
 # 8.5   2.76022
 # 8.75  3.87568
 # 9.0   5.40385
 # ```
 #
-# As illustrated above, the value returned by [`extract_result`](@ref) is a 
-# two-dimensional array (a `Matrix`), with each column corresponding to a 
+# As illustrated above, the value returned by [`extract_result`](@ref) is a
+# two-dimensional array (a `Matrix`), with each column corresponding to a
 # parameter of the [`@outputs`](@ref) macro.
 
 # #### Using the `analyze` Function Return Value
-# The variable returned from [`analyze`](@ref) can be used in a similar way to the result file to obtain any quantity 
+# The variable returned from [`analyze`](@ref) can be used in a similar way to the result file to obtain any quantity
 # available to the [`@outputs`](@ref) macro. For this purpose we pass the return value of the `analyze` function
 # as the first argument to the [`extract_result`](@ref) function:
 #
@@ -556,14 +559,14 @@ flist = union(7:0.5:10, 20:0.5:25) # Two frequency bands
 # 3.75  3.3334
 # 4.0   2.42903
 # 4.25  1.64223
-# ⋮     
+# ⋮
 # 8.25  1.91583
 # 8.5   2.76022
 # 8.75  3.87568
 # 9.0   5.40385
 # ```
 #
-# As in the previous example, the value returned by [`extract_result`](@ref) is a two-dimensional array (a `Matrix`), 
+# As in the previous example, the value returned by [`extract_result`](@ref) is a two-dimensional array (a `Matrix`),
 # with each column corresponding to a parameter of the [`@outputs`](@ref) macro.
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "subslide"}}
@@ -575,20 +578,20 @@ flist = union(7:0.5:10, 20:0.5:25) # Two frequency bands
 # ### Exporting Analysis Results to TEP Files
 # The vector of `Result` objects returned by the [`analyze`](@ref) function (or the corresponding
 # result file) can be converted to a TICRA-compatible TEP (tabulated electrical properties) file
-# using the function [`res2tep`](@ref).  TEP files contain the equivalent of the full 
+# using the function [`res2tep`](@ref).  TEP files contain the equivalent of the full
 # 4×4 scattering matrix computed by PSSFSS.  Therefore, there is no requirement/limitation for unit cell geometry
 # to exhibit any particular symmetry when results are to be exported to a TEP file.  There are, however, requirements
 # on the choice of steering angles to be analyzed.  For details, see the documentation of [`res2tep`](@ref).
-# Sample code for creating a TEP file is shown in [this example](@ref "TEP File Creation"). 
+# Sample code for creating a TEP file is shown in [this example](@ref "TEP File Creation").
 
 #nb # %% A slide [markdown] {"slideshow": {"slide_type": "subslide"}}
 # ### Exporting Analysis Results to Fresnel Tables
 # The vector of `Result` objects returned by the [`analyze`](@ref) function (or the corresponding
 # result file) can be converted to an HFSS SBR+-compatible Fresnel table
 # using the function [`res2fresnel`](@ref).  Fresnel tables contain reflection
-# and transmission coefficients for only "front" surface incidence, and only for co-polarized 
-# (TE → TE and TM → TM) scattering. In addition, coefficients for only one azimuth angle ϕ are 
+# and transmission coefficients for only "front" surface incidence, and only for co-polarized
+# (TE → TE and TM → TM) scattering. In addition, coefficients for only one azimuth angle ϕ are
 # retained in such a table.  These limitations impose restrictions on the type of structure that
 # can be analyzed for use in generating a valid Fresnel table. For details, see the documentation
-# of [`res2fresnel`](@ref). Sample code for creating a Fresnel table is shown in 
-# [this example](@ref "Fresnel Table Creation"). 
+# of [`res2fresnel`](@ref). Sample code for creating a Fresnel table is shown in
+# [this example](@ref "Fresnel Table Creation").

--- a/docs/literate/manual.jl
+++ b/docs/literate/manual.jl
@@ -364,8 +364,9 @@ steer = (psi1=10:10:40, psi2=0) # Can use ASCII names if desired
 flist = 12
 flist = 2:2:12 # same as [2,4,6,8,10,12]
 flist = union(7:0.5:10, 20:0.5:25) # Two frequency bands
-# To specify frequencies in, say THz, use the [string macro](https://docs.julialang.org/en/v1/) from the
-# [`Unitful`](https://github.com/JuliaPhysics/Unitful.jl) package, provided as a convenience by PSSFSS:
+# To specify frequencies in, say THz, use the
+# [string macro](https://docs.julialang.org/en/v1/manual/metaprogramming/#meta-non-standard-string-literals) from the
+# [`Unitful`](https://github.com/JuliaPhysics/Unitful.jl) package, which is exported for convenience by PSSFSS:
 flist = (2:2:12) * u"THz"
 # Any `Unitful` unit having the correct dimension (inverse time) can be used (including of course `u"GHz"`).
 

--- a/src/Layers.jl
+++ b/src/Layers.jl
@@ -21,8 +21,8 @@ in a Gblock, an instance of Layer also specifies the periodicity (via the
 reciprocal lattice vectors) and stores the mode constants for the Floquet modes present
 in the layer.
 
-    Layer(;width::0mm, ϵᵣ=1.0, tanδ=0.0, μᵣ=1.0, mtanδ=0.0)
-    Layer(;width::0mm, epsr=1.0, tandel=0.0, mur=1.0, mtandel=0.0)
+    Layer(; width=0mm, ϵᵣ=1.0, tanδ=0.0, μᵣ=1.0, mtanδ=0.0)
+    Layer(; width=0mm, epsr=1.0, tandel=0.0, mur=1.0, mtandel=0.0)
 
 Create a `Layer` instance with the specified electrical properties.  All arguments
 are optional keyword arguments with default values as shown above. They can be
@@ -33,15 +33,13 @@ reference planes are located at the surfaces just adjacent to these semi-infinit
 
 # Arguments
 - `width`: The layer width (i.e. thickness) expressed as a
-        [`Unitful`](https://github.com/timholy/Unitful.jl)
-        length quantity. For convenience the following unit
-        suffixes are exported by this module: `m`, `cm`, `mil`, `inch`,
-        so one can specify, e.g., `width=20mil`.  Note that `width` can
-        be negative for the first and/or final layer of the composite structure,
-        which has the effect of shifting the phase reference plane towards
-        the interior of the composite structure.  This is sometimes needed
-        when interfacing with other programs, such as TEP file generation for
-        Ticra's `GRASP` program.
+  [`Unitful`](https://github.com/timholy/Unitful.jl) length quantity. For convenience the
+  following unit suffixes are exported by this module: `m`, `cm`, `mm`, `μm`, `micron`,
+  `mil`, and `inch`.  So one can specify, e.g., `width=20mil`.  Note that `width` can
+  be negative for the first and/or final layer of the composite structure, which has the
+  effect of shifting the phase reference plane towards the interior of the composite structure.
+  This is sometimes needed when interfacing with other programs, such as TEP file generation
+  for Ticra's `GRASP` program.
 - `ϵᵣ` or `epsr`: Relative permittivity of the dielectric.
 - `tanδ` or `tandel`: Loss tangent (electrical) of the dielectric.
 - `μᵣ` or `mur`: Relative permeability of the dielectric.

--- a/src/Outputs.jl
+++ b/src/Outputs.jl
@@ -291,12 +291,24 @@ AR21DB(n) = ardb(2, 1, n)
 AR22DB(n) = ardb(2, 2, n)
 
 
+FTHZ = Outfun("FTHZ") do o
+    o.FGHz * 1e-3
+end
+
 FGHZ = Outfun("FGHZ") do o
     o.FGHz
 end
 
 FMHZ = Outfun("FMHZ") do o
-    o.FGHz * 1000
+    o.FGHz * 1e3
+end
+
+FKHZ = Outfun("FKHZ") do o
+    o.FGHz * 1e6
+end
+
+FHZ = Outfun("FHZ") do o
+    o.FGHz * 1e9
 end
 
 THETA = Outfun("THETA") do o

--- a/src/PSSFSS.jl
+++ b/src/PSSFSS.jl
@@ -27,7 +27,8 @@ using DelimitedFiles: writedlm
 using Printf: @sprintf
 using LinearAlgebra: ×, norm, ⋅, factorize, lu!, ldiv!, BLAS
 using StaticArrays: StaticArrays, SVector, SArray, @SVector, MArray
-using Unitful: ustrip, @u_str
+using Unitful: ustrip
+@reexport using Unitful: @u_str
 using Logging: with_logger
 using ProgressMeter
 using PrecompileTools
@@ -84,7 +85,9 @@ Generate output files as specified in `outlist`.
 ## Positional Arguments
 - `strata`:  A vector of `Layer` and `RWGSheet` objects. The first and last entries must be of type `Layer`.
 
-- `flist`: An iterable containing the analysis frequencies in GHz.
+- `flist`: An iterable containing the analysis frequencies. By default these are assumed to be numbers that
+  are interpreted to be in GHz. However, they can instead be any `Unitful` quantities with dimension of frequency
+  (i.e. inverse time).  For example `(1.5:0.1:3) * u"THz"` would be acceptable as an input.
 
 - `steering`: A length 2 `NamedTuple` containing as keys the steering parameter labels and as values
   the iterables that define the values of steering parameters to be analyzed.
@@ -144,9 +147,13 @@ function analyze(strata::Vector, flist, steering; outlist=[], logfile="pssfss.lo
     sint = cumsum(islayer)[issheet] # sint[k] contains dielectric interface number of k'th sheet
     junc = zeros(Int, nj)
     junc[sint] = 1:ns #  junc[i] is the sheet number present at interface i, or 0 if no sheet is there
-    freqstemp = float.(collect(flist))
+    if isa(first(flist), Unitful.Quantity)
+        freqstemp = [float(Unitful.ustrip(u"GHz", f)) for f in flist]
+    else
+        freqstemp = float.(collect(flist))
+    end
     if length(freqstemp) < 2
-        freqs = Float64[freqstemp]
+        freqs = Float64[only(freqstemp)]
     else
         freqs::Vector{Float64} = freqstemp
     end

--- a/src/PSSFSS.jl
+++ b/src/PSSFSS.jl
@@ -148,6 +148,7 @@ function analyze(strata::Vector, flist, steering; outlist=[], logfile="pssfss.lo
     junc = zeros(Int, nj)
     junc[sint] = 1:ns #  junc[i] is the sheet number present at interface i, or 0 if no sheet is there
     if isa(first(flist), Unitful.Quantity)
+        first(flist) isa Unitful.Quantity{<:Real, Unitful.𝐓^-1} || throw(ArgumentError("Bad flist units"))
         freqstemp = [float(Unitful.ustrip(u"GHz", f)) for f in flist]
     else
         freqstemp = float.(collect(flist))

--- a/test/full_test.jl
+++ b/test/full_test.jl
@@ -5,6 +5,7 @@ using LinearAlgebra: norm
 using Test
 using Logging: Error, ConsoleLogger, default_metafmt, global_logger
 using MetalSurfaceImpedance: Zsurface
+using Unitful: @u_str
 
 
 testlogger = ConsoleLogger(stderr, Error,
@@ -129,6 +130,32 @@ end
     s11_file = extract_result(resultfile, @outputs s11(te,te))[1]
     @test s11 == s11_file
     @test s11 ≈ s11_expected atol=1e-5
+end
+
+make_slab_strata(width) = [Layer(), Layer(width = width, ϵᵣ = 6.5), Layer()]
+
+@testset "LengthUnits" begin
+    @test_throws TypeError Layer(width = 20u"GHz")
+
+    results1 = analyze(make_slab_strata(10mm), 10, (θ=0, ϕ=0), logfile=devnull, resultfile=devnull, showprogress=false)
+    results2 = analyze(make_slab_strata(10*1000μm), 10, (θ=0, ϕ=0), logfile=devnull, resultfile=devnull, showprogress=false)
+    results3 = analyze(make_slab_strata(10*1000micron), 10, (θ=0, ϕ=0), logfile=devnull, resultfile=devnull, showprogress=false)
+    @test only(results1).gsm.s11 == only(results2).gsm.s11 == only(results3).gsm.s11
+    @test only(results1).gsm.s12 == only(results2).gsm.s12 == only(results3).gsm.s12
+    @test only(results1).gsm.s21 == only(results2).gsm.s21 == only(results3).gsm.s21
+    @test only(results1).gsm.s22 == only(results2).gsm.s22 == only(results3).gsm.s22
+end
+
+@testset "FrequencyUnits" begin
+    strata = make_slab_strata(10mm)
+    @test_throws ArgumentError analyze(strata, 10mm, (θ=0, ϕ=0), logfile=devnull, resultfile=devnull, showprogress=false)
+
+    results1 = analyze(strata, 10, (θ=0, ϕ=0), logfile=devnull, resultfile=devnull, showprogress=false)
+    results2 = analyze(strata, 1e-2u"THz", (θ=0, ϕ=0), logfile=devnull, resultfile=devnull, showprogress=false)
+    @test only(results1).gsm.s11 == only(results2).gsm.s11
+    @test only(results1).gsm.s12 == only(results2).gsm.s12
+    @test only(results1).gsm.s21 == only(results2).gsm.s21
+    @test only(results1).gsm.s22 == only(results2).gsm.s22
 end
 
 global_logger(oldlogger)


### PR DESCRIPTION
* In addition to non-Unitful values, allow any Unitful frequency quantity when passing the `flist` argument to the `analyze` function.
* Add `FkHz`, `FHz` and `FTHz` to list of permissible `@outputs` parameters.
* Update the `Layer` constructor docstring to reflect new `micron` and `μm` units for `width` keyword argument.
* Update Triangulate compat entry to 3